### PR TITLE
Add ru-RU language files

### DIFF
--- a/App_LocalResources/Browser.aspx.ru-RU.resx
+++ b/App_LocalResources/Browser.aspx.ru-RU.resx
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System" name="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.DefaultModifiers" type="System.CodeDom.MemberAttributes, System">
+    <value>Скрытое</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.TrayLargeIcon" type="System.Boolean, mscorlib">
+    <value>Нет</value>
+  </data>
+  <data name="$this.TrayAutoArrange" type="System.Boolean, mscorlib">
+    <value>Да</value>
+  </data>
+  <data name="cmdCancel.Text" xml:space="preserve">
+    <value>Закрыть окно</value>
+  </data>
+  <data name="cmdClose.Text" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="lblConFiles.Text" xml:space="preserve">
+    <value>Содержит файлы:</value>
+  </data>
+  <data name="lblCurrent.Text" xml:space="preserve">
+    <value>Текущая папка:</value>
+  </data>
+  <data name="lblSubDirs.Text" xml:space="preserve">
+    <value>Папки:</value>
+  </data>
+  <data name="cmdDownload.Help" xml:space="preserve">
+    <value>Скачать выбранный файл</value>
+  </data>
+  <data name="cmdDownload.Text" xml:space="preserve">
+    <value>Скачать файл</value>
+  </data>
+  <data name="cmdUpload.Help" xml:space="preserve">
+    <value>Подгрузить новый файл</value>
+  </data>
+  <data name="cmdUpload.Text" xml:space="preserve">
+    <value>Подгрузить файл</value>
+  </data>
+  <data name="Error1.Text" xml:space="preserve">
+    <value>Вы не вошли в систему!</value>
+  </data>
+  <data name="Error2.Text" xml:space="preserve">
+    <value>Запрещенное расширение имени файла!</value>
+  </data>
+  <data name="Error3.Text" xml:space="preserve">
+    <value>Запрещенное расширение имени файла!</value>
+  </data>
+  <data name="Error4.Text" xml:space="preserve">
+    <value>У Вас недостаточно прав для просмотра этой папки!</value>
+  </data>
+  <data name="Error5.Text" xml:space="preserve">
+    <value>Не выбран файл.</value>
+  </data>
+  <data name="cmdUploadCancel.Text" xml:space="preserve">
+    <value>Отменить подгрузку</value>
+  </data>
+  <data name="cmdUploadNow.Text" xml:space="preserve">
+    <value>Подгрузить сейчас</value>
+  </data>
+  <data name="lblUrlType.Text" xml:space="preserve">
+    <value>Выберите тип URL:</value>
+  </data>
+  <data name="lblChoosetab.Text" xml:space="preserve">
+    <value>Выберите страницу:</value>
+  </data>
+  <data name="cmdCreate.Help" xml:space="preserve">
+    <value>Новая подпапка</value>
+  </data>
+  <data name="cmdCreate.Text" xml:space="preserve">
+    <value>Новая папка</value>
+  </data>
+  <data name="cmdDelete.Help" xml:space="preserve">
+    <value>Удалить выбранный файл</value>
+  </data>
+  <data name="cmdDelete.Text" xml:space="preserve">
+    <value>Удалить файл</value>
+  </data>
+  <data name="cmdCreateFolder.Text" xml:space="preserve">
+    <value>Создать сейчас</value>
+  </data>
+  <data name="chkAspect.Text" xml:space="preserve">
+    <value>Сохранять соотношение сторон</value>
+  </data>
+  <data name="chkHumanFriendy.Text" xml:space="preserve">
+    <value>Человеко понимаемый URL</value>
+  </data>
+  <data name="cmdResizeCancel.Text" xml:space="preserve">
+    <value>Отменить изменение размера</value>
+  </data>
+  <data name="cmdResizeNow.Text" xml:space="preserve">
+    <value>Изменить размер сейчас</value>
+  </data>
+  <data name="cmdResizer.Help" xml:space="preserve">
+    <value>Редактирование выбранного изображения</value>
+  </data>
+  <data name="cmdResizer.Text" xml:space="preserve">
+    <value>Редактор изображений</value>
+  </data>
+  <data name="lblHeight.Text" xml:space="preserve">
+    <value>Новая высота:</value>
+  </data>
+  <data name="lblThumbName.Text" xml:space="preserve">
+    <value>Новое имя файла:</value>
+  </data>
+  <data name="lblWidth.Text" xml:space="preserve">
+    <value>Новая ширина:</value>
+  </data>
+  <data name="AreYouSure.Text" xml:space="preserve">
+    <value>Уверены, что хотите удалить этот файл?</value>
+  </data>
+  <data name="lblImgQuality.Text" xml:space="preserve">
+    <value>Качество изображения (степень сжатия):</value>
+  </data>
+  <data name="cmdCrop.Text" xml:space="preserve">
+    <value>Обрезать</value>
+  </data>
+  <data name="cmdCropCancel.Text" xml:space="preserve">
+    <value>Отменить редактирование</value>
+  </data>
+  <data name="cmdCropNow.Text" xml:space="preserve">
+    <value>Новое изображение</value>
+  </data>
+  <data name="cmdResize2.Text" xml:space="preserve">
+    <value>Изменить размер</value>
+  </data>
+  <data name="cmdRotate.Text" xml:space="preserve">
+    <value>Повернуть</value>
+  </data>
+  <data name="cmdZoom.Text" xml:space="preserve">
+    <value>Мастабировать</value>
+  </data>
+  <data name="imgOriginal.Text" xml:space="preserve">
+    <value>Исходное изображение (масштабировано под экран)</value>
+  </data>
+  <data name="imgResized.Text" xml:space="preserve">
+    <value>Предпросмотр изображения измененного размера (масштабировано под экран)</value>
+  </data>
+  <data name="lblClearPreview.Text" xml:space="preserve">
+    <value>Очистить предпросмотр</value>
+  </data>
+  <data name="lblCropInfo.Text" xml:space="preserve">
+    <value>Здесь Вы сможете увидеть новое отредактированное изображение</value>
+  </data>
+  <data name="lblOriginal.Text" xml:space="preserve">
+    <value>Оригинал:</value>
+  </data>
+  <data name="lblOtherTools.Text" xml:space="preserve">
+    <value>Другие инструменты:</value>
+  </data>
+  <data name="lblPreview.Text" xml:space="preserve">
+    <value>Предпросмотр:</value>
+  </data>
+  <data name="lblResizeHeader.Text" xml:space="preserve">
+    <value>Редактор изображений: Изменить размер</value>
+  </data>
+  <data name="lblResizeHeader2.Text" xml:space="preserve">
+    <value>Редактор изображений: Обрезать, Масштабировать и Повернуть</value>
+  </data>
+  <data name="lblShowPreview.Text" xml:space="preserve">
+    <value>Показать предпросмотр</value>
+  </data>
+  <data name="cmdCreateCancel.Text" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="lblNewFoldName.Text" xml:space="preserve">
+    <value>Имя новой папки:</value>
+  </data>
+  <data name="LabelAnchor.Text" xml:space="preserve">
+    <value>Выберите якорь на странице:</value>
+  </data>
+  <data name="TrackClicks.Text" xml:space="preserve">
+    <value>Учитывать число кликов?</value>
+  </data>
+  <data name="absLnk.Text" xml:space="preserve">
+    <value>Абсолютный URL  - &lt;em&gt;'http://www.MyWebsite.com/Images/MyImage.jpg'&lt;/em&gt;</value>
+  </data>
+  <data name="lnkClick.Text" xml:space="preserve">
+    <value>Относительный защищенный URL  - &lt;em&gt;'/LinkClick.aspx?fileticket=xyz'&lt;/em&gt;</value>
+  </data>
+  <data name="relLnk.Text" xml:space="preserve">
+    <value>Относительный URL  - &lt;em&gt;'/Images/MyImage.jpg'&lt;/em&gt;</value>
+  </data>
+  <data name="Wait.Text" xml:space="preserve">
+    <value>Подождите, пожалуйста...</value>
+  </data>
+  <data name="WaitMessage.Text" xml:space="preserve">
+    <value>Загружаю страницу и разбираю якоря.</value>
+  </data>
+  <data name="ExtraTabOptions.Text" xml:space="preserve">
+    <value>Настройки вкладок:</value>
+  </data>
+  <data name="LabelTabLanguage.Text" xml:space="preserve">
+    <value>Дополнительный параметр языка:</value>
+  </data>
+  <data name="None.Text" xml:space="preserve">
+    <value>Нет</value>
+  </data>
+  <data name="FileLink.Text" xml:space="preserve">
+    <value>Ссылка на файл</value>
+  </data>
+  <data name="PageLink.Text" xml:space="preserve">
+    <value>Ссылка на страницу</value>
+  </data>
+  <data name="DetailView.Text" xml:space="preserve">
+    <value>Подробно</value>
+  </data>
+  <data name="DetailViewTitle.Text" xml:space="preserve">
+    <value>Каждый файл отображается с большим значком предпросмотра изображения, именем файла и другой информацией о файле</value>
+  </data>
+  <data name="IconsView.Text" xml:space="preserve">
+    <value>Значки</value>
+  </data>
+  <data name="IconsViewTitle.Text" xml:space="preserve">
+    <value>Все файлы отображаются с предпросмотром изображения в виде плитки</value>
+  </data>
+  <data name="ListView.Text" xml:space="preserve">
+    <value>Список</value>
+  </data>
+  <data name="ListViewTitle.Text" xml:space="preserve">
+    <value>Файлы отображаются с малельким значком предпросмотра изрображения, именем файла и информацией о файле</value>
+  </data>
+  <data name="FirstPage.Text" xml:space="preserve">
+    <value>Первая</value>
+  </data>
+  <data name="GoTo.Text" xml:space="preserve">
+    <value>Перейти к</value>
+  </data>
+  <data name="LastPage.Text" xml:space="preserve">
+    <value>Последняя</value>
+  </data>
+  <data name="NextPage.Text" xml:space="preserve">
+    <value>След.</value>
+  </data>
+  <data name="PreviousPage.Text" xml:space="preserve">
+    <value>Пред.</value>
+  </data>
+  <data name="SortAscending.Help" xml:space="preserve">
+    <value>Сортировать список файлов по имени файла, в порядке возрастания</value>
+  </data>
+  <data name="SortAscending.Text" xml:space="preserve">
+    <value>По возрастанию</value>
+  </data>
+  <data name="SortDescending.Help" xml:space="preserve">
+    <value>Сортировать список файлов по имени файла, в порядке убывания</value>
+  </data>
+  <data name="SortDescending.Text" xml:space="preserve">
+    <value>По убыванию</value>
+  </data>
+  <data name="lnkAbsClick.Text" xml:space="preserve">
+    <value>Абсолютный защищенный URL  - &lt;em&gt;'http://www.MyWebsite.com/LinkClick.aspx?fileticket=xyz'&lt;/em&gt;</value>
+  </data>
+  <data name="SpaceUsed.Text" xml:space="preserve">
+    <value>Место на диске: {0} of {1}</value>
+  </data>
+  <data name="UnlimitedSpace.Text" xml:space="preserve">
+    <value>[без ограничений]</value>
+  </data>
+  <data name="Syncronize.Help" xml:space="preserve">
+    <value>Синхронизировать папку с базой данных</value>
+  </data>
+  <data name="Syncronize.Text" xml:space="preserve">
+    <value>Синхронизировать папку</value>
+  </data>
+  <data name="FileSizeRestriction.Text" xml:space="preserve">
+    <value>Максимальный размер подгружаемого файла {0} Мб. &lt;br /&gt; Разрешенные типы файлов: "{1}"</value>
+  </data>
+  <data name="FileToBig.Text" xml:space="preserve">
+    <value>Файл слишком большой.</value>
+  </data>
+  <data name="OverrideFile.Text" xml:space="preserve">
+    <value>Перезаписать файл, если существует, или создать файл с именем, к которому будет добавлено _1?</value>
+  </data>
+  <data name="FileToBigMessage.Text" xml:space="preserve">
+    <value>Размер подгружаемого файла больше, чем максимально разрешенный!</value>
+  </data>
+  <data name="AddFiles.Text" xml:space="preserve">
+    <value>Добавить файл(ы)...</value>
+  </data>
+  <data name="DropHere.Text" xml:space="preserve">
+    <value>Перетащите файл(ы) сюда</value>
+  </data>
+  <data name="StartUploads.Text" xml:space="preserve">
+    <value>Начать подгрузку</value>
+  </data>
+</root>

--- a/App_LocalResources/EditorConfigManager.ascx.ru-RU.resx
+++ b/App_LocalResources/EditorConfigManager.ascx.ru-RU.resx
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System" name="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.DefaultModifiers" type="System.CodeDom.MemberAttributes, System">
+    <value>Скрытое</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.TrayLargeIcon" type="System.Boolean, mscorlib">
+    <value>Нет</value>
+  </data>
+  <data name="$this.TrayAutoArrange" type="System.Boolean, mscorlib">
+    <value>Да</value>
+  </data>
+  <data name="EditorMangerPageName.Text" xml:space="preserve">
+    <value>Управление редактором HTML</value>
+  </data>
+  <data name="EditorMangerPageDescription.Text" xml:space="preserve">
+    <value>Предоставляет возможность изменения настроек поставщика редактора HTML</value>
+  </data>
+  <data name="EditorMangerName.Text" xml:space="preserve">
+    <value>Настройки поставщика CKEditor</value>
+  </data>
+</root>

--- a/App_LocalResources/Options.aspx.ru-RU.resx
+++ b/App_LocalResources/Options.aspx.ru-RU.resx
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System" name="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.DefaultModifiers" type="System.CodeDom.MemberAttributes, System">
+    <value>Скрытое</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="$this.TrayLargeIcon" type="System.Boolean, mscorlib">
+    <value>Нет</value>
+  </data>
+  <data name="$this.TrayAutoArrange" type="System.Boolean, mscorlib">
+    <value>Да</value>
+  </data>
+  <data name="lblHeader.Text" xml:space="preserve">
+    <value>Информация</value>
+  </data>
+  <data name="lblModType.Text" xml:space="preserve">
+    <value>Тип модуля:</value>
+  </data>
+  <data name="lblModName.Text" xml:space="preserve">
+    <value>Имя модуля:</value>
+  </data>
+  <data name="lblModInst.Text" xml:space="preserve">
+    <value>Экземпляр модуля:</value>
+  </data>
+  <data name="lblUName.Text" xml:space="preserve">
+    <value>Имя пользователя:</value>
+  </data>
+  <data name="lblSettings.Text" xml:space="preserve">
+    <value>Настройки</value>
+  </data>
+  <data name="btnOK.Text" xml:space="preserve">
+    <value>Сохранить</value>
+  </data>
+  <data name="btnCancel.Text" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
+  <data name="Error1.Text" xml:space="preserve">
+    <value>У Вас недостаточно прав для просмотра этой страницы!</value>
+  </data>
+  <data name="lblPage.Text" xml:space="preserve">
+    <value>Страница:</value>
+  </data>
+  <data name="lblSetFor.Text" xml:space="preserve">
+    <value>Изменить настройки:</value>
+  </data>
+  <data name="lblBrowAllow.Text" xml:space="preserve">
+    <value>Разрешенные роли:</value>
+  </data>
+  <data name="lblBrowser.Text" xml:space="preserve">
+    <value>Браузер файлов:</value>
+  </data>
+  <data name="lblBrowsSec.Text" xml:space="preserve">
+    <value>Настройки браузера файлов</value>
+  </data>
+  <data name="lblCSSURL.Text" xml:space="preserve">
+    <value>CSS области редактора:</value>
+  </data>
+  <data name="lblPortal.Text" xml:space="preserve">
+    <value>Название сайта:</value>
+  </data>
+  <data name="lblStyles.Text" xml:space="preserve">
+    <value>Стили редактора</value>
+  </data>
+  <data name="lblToolbars.Text" xml:space="preserve">
+    <value>Панели инструментов:</value>
+  </data>
+  <data name="lnkRemove.Text" xml:space="preserve">
+    <value>Удаление настроек</value>
+  </data>
+  <data name="lblInfo.Text" xml:space="preserve">
+    <value>Настройки сохранены. Обновите редактор или перезагрузите страницу, чтобы увидеть изменения!</value>
+  </data>
+  <data name="lblInfoDel.Text" xml:space="preserve">
+    <value>Настройки удалены</value>
+  </data>
+  <data name="lblBlanktext.Text" xml:space="preserve">
+    <value>Пустой текст:</value>
+  </data>
+  <data name="lblRole.Text" xml:space="preserve">
+    <value>Роль</value>
+  </data>
+  <data name="lblSelToolb.Text" xml:space="preserve">
+    <value>Выберите панель инструментов</value>
+  </data>
+  <data name="Options.Text" xml:space="preserve">
+    <value>Пользовательские настройки редактора</value>
+  </data>
+  <data name="lblMainSet.Text" xml:space="preserve">
+    <value>Главные настройки</value>
+  </data>
+  <data name="lblBrowserDirs.Text" xml:space="preserve">
+    <value>Использовать подпапки для не-администраторов (..\Portals\0\userfiles\username)?</value>
+  </data>
+  <data name="lblTemplates.Text" xml:space="preserve">
+    <value>Шаблона редактора</value>
+  </data>
+  <data name="lblTemplFiles.Text" xml:space="preserve">
+    <value>Файл шаблонов редактора:</value>
+  </data>
+  <data name="lblCustomConfig.Text" xml:space="preserve">
+    <value>Пользовательский файл настроек:</value>
+  </data>
+  <data name="AddToolbar.Text" xml:space="preserve">
+    <value>Новый набор панелей инструментов</value>
+  </data>
+  <data name="CancelToolbar.Text" xml:space="preserve">
+    <value>Отменить редактирование</value>
+  </data>
+  <data name="DeleteToolbar.Text" xml:space="preserve">
+    <value>Удалить выбранный набор панелей инструментов</value>
+  </data>
+  <data name="EditToolbar.Text" xml:space="preserve">
+    <value>Редактировать набор панелей инструментов</value>
+  </data>
+  <data name="lblCustomToolbars.Text" xml:space="preserve">
+    <value>Пользовательские панели инструментов</value>
+  </data>
+  <data name="lblToolbarList.Text" xml:space="preserve">
+    <value>Список пользовательских панелей инструментов:</value>
+  </data>
+  <data name="lblToolbName.Text" xml:space="preserve">
+    <value>Название панели:</value>
+  </data>
+  <data name="lblToolbSet.Text" xml:space="preserve">
+    <value>Доступные кнопки:</value>
+  </data>
+  <data name="SaveToolbar.Text" xml:space="preserve">
+    <value>Сохранить набор панелей</value>
+  </data>
+  <data name="lblUseJquery.Text" xml:space="preserve">
+    <value>Использовать адаптор jQuery?</value>
+  </data>
+  <data name="lblHeight.Text" xml:space="preserve">
+    <value>Высота редактора ('px' или '%') :</value>
+  </data>
+  <data name="lblWidth.Text" xml:space="preserve">
+    <value>Ширина редактора ('px' или '%') :</value>
+  </data>
+  <data name="lblImExport.Text" xml:space="preserve">
+    <value>Импорт/экспорт текущих настроек...</value>
+  </data>
+  <data name="lblResizeHeight.Text" xml:space="preserve">
+    <value>Высота изображений по-умолчанию:</value>
+  </data>
+  <data name="lblResizeWidth.Text" xml:space="preserve">
+    <value>Ширина изображений по-умолчанию:</value>
+  </data>
+  <data name="lnkExport.Text" xml:space="preserve">
+    <value>Экспорт</value>
+  </data>
+  <data name="lnkImport.Text" xml:space="preserve">
+    <value>Импорт</value>
+  </data>
+  <data name="BadImportXml.Text" xml:space="preserve">
+    <value>Неверный или плохой файл XML!</value>
+  </data>
+  <data name="Export.Text" xml:space="preserve">
+    <value>Текущие настройки редактора экспортированы!</value>
+  </data>
+  <data name="Imported.Text" xml:space="preserve">
+    <value>Настройки редактора импортированы для</value>
+  </data>
+  <data name="lblInjectSyntaxJs.Text" xml:space="preserve">
+    <value>Добавить ссылку на SyntaxHighlighter Js?</value>
+  </data>
+  <data name="UploadFolderLabel.Text" xml:space="preserve">
+    <value>Папка подгрузки по-умолчанию:</value>
+  </data>
+  <data name="BrowserRootFolder.Text" xml:space="preserve">
+    <value>Корневая папка браузера файлов:</value>
+  </data>
+  <data name="lblAutoCreateFileThumbNails.Text" xml:space="preserve">
+    <value>Создавать миниатюры изображений для предпросмотра:</value>
+  </data>
+  <data name="lblShowPageLinksTabFirst.Text" xml:space="preserve">
+    <value>Показывать вкладку ссылок на страницы первой:</value>
+  </data>
+  <data name="lblUseAnchorSelector.Text" xml:space="preserve">
+    <value>Использовать выбор якорей (автоматически находит все якоря на выбранной странице):</value>
+  </data>
+  <data name="FileListViewModeLabel.Text" xml:space="preserve">
+    <value>Режим списка файлов по-умолчанию:</value>
+  </data>
+  <data name="SettingsExportTitle.Text" xml:space="preserve">
+    <value>Экспорт настроек</value>
+  </data>
+  <data name="SettingsImportTitle.Text" xml:space="preserve">
+    <value>Импорт настроек</value>
+  </data>
+  <data name="ExportNow.Text" xml:space="preserve">
+    <value>Экспортировать сейчас</value>
+  </data>
+  <data name="ImportNow.Text" xml:space="preserve">
+    <value>Импортировать сейчас</value>
+  </data>
+  <data name="FileListPageSizeLabel.Text" xml:space="preserve">
+    <value>Размер страницы списка файлов (0=не разбивать на страницы)</value>
+  </data>
+  <data name="Remove.Help" xml:space="preserve">
+    <value>Настройки будут удалены только для текущего {0}.</value>
+  </data>
+  <data name="Remove.Text" xml:space="preserve">
+    <value>Удалить настройки {0}</value>
+  </data>
+  <data name="RemoveAll.Help" xml:space="preserve">
+    <value>Удалить настройки {0} для всего сайта.</value>
+  </data>
+  <data name="RemoveAll.Text" xml:space="preserve">
+    <value>Удалить настройки {0}</value>
+  </data>
+  <data name="CreateGroupLabel.Text" xml:space="preserve">
+    <value>Новая группа</value>
+  </data>
+  <data name="CreateGroupTitle.Text" xml:space="preserve">
+    <value>Добавить новую группу в набор панелей?</value>
+  </data>
+  <data name="DeleteGroup.Text" xml:space="preserve">
+    <value>Удалить эту группу панелей?</value>
+  </data>
+  <data name="DeleteToolbarButton.Text" xml:space="preserve">
+    <value>Удалить эту кнопку?</value>
+  </data>
+  <data name="EditGroupName.Text" xml:space="preserve">
+    <value>Нажмите для изменения названия группы</value>
+  </data>
+  <data name="NewGroupName.Text" xml:space="preserve">
+    <value>Новая группа</value>
+  </data>
+  <data name="SaveGroupName.Text" xml:space="preserve">
+    <value>Сохранить название группы</value>
+  </data>
+  <data name="lblToolbarPriority.Text" xml:space="preserve">
+    <value>Приоритет набора панелей:</value>
+  </data>
+  <data name="ToolbarGroupsLabel.Text" xml:space="preserve">
+    <value>Группы панелей:</value>
+  </data>
+  <data name="CodeMirrorLabel.Text" xml:space="preserve">
+    <value>Тема CodeMirror (для подсветки исходного кода):</value>
+  </data>
+  <data name="lblSkin.Text" xml:space="preserve">
+    <value>Шаблон оформления</value>
+  </data>
+  <data name="NoJava.Text" xml:space="preserve">
+    <value>&lt;strong&gt;Работа CKEditor требует использования JavaScript&lt;/strong&gt;. В браузере без поддержки или с выключенным JavaScript, как в Вашем случае, Вы должны видеть содержимое в формате HTML, а также редактировать его - но без пользовательского интерфейса редактора.</value>
+  </data>
+  <data name="lblEditorConfig.Text" xml:space="preserve">
+    <value>Настройки редактора</value>
+  </data>
+  <data name="ModuleError.Text" xml:space="preserve">
+    <value>Настройки редактора для экземпляра модуля могут быть просмотрены и загружены только из этого экземпляра модуля!</value>
+  </data>
+  <data name="ModuleHeader.Text" xml:space="preserve">
+    <value>Настройки поставщика CKEditor</value>
+  </data>
+  <data name="PortalOnlyLabel.Text" xml:space="preserve">
+    <value>Показывать настройки только для этого сайта, или для всех сайтов?</value>
+  </data>
+  <data name="Wait.Text" xml:space="preserve">
+    <value>Подождите, пожалуйста...</value>
+  </data>
+  <data name="WaitMessage.Text" xml:space="preserve">
+    <value>Загружаю страницу настроек.</value>
+  </data>
+  <data name="PortalOnly.Text" xml:space="preserve">
+    <value>Только сайт</value>
+  </data>
+  <data name="ModuleHasSettingLabel.Text" xml:space="preserve">
+    <value>Содержит настройки модуля</value>
+  </data>
+  <data name="ModuleNoSettingLabel.Text" xml:space="preserve">
+    <value>Не содержит настроек модуля</value>
+  </data>
+  <data name="PageHasSettingLabel.Text" xml:space="preserve">
+    <value>Содержит настройки страницы</value>
+  </data>
+  <data name="PageNoSettingLabel.Text" xml:space="preserve">
+    <value>Не содержит настроек страницы</value>
+  </data>
+  <data name="PortalHasSettingLabel.Text" xml:space="preserve">
+    <value>Содержит настройки сайта</value>
+  </data>
+  <data name="PortalNoSettingLabel.Text" xml:space="preserve">
+    <value>Не содержит настроек сайта</value>
+  </data>
+  <data name="IconLegendLabel.Text" xml:space="preserve">
+    <value>Легенда</value>
+  </data>
+  <data name="EditorConfigWarning.Text" xml:space="preserve">
+    <value>&lt;strong&gt;Информация:&lt;/strong&gt; Расположенные ниже настройки предназначены только для очень опытных пользователей, так что меняйте что-нибудь в них только в том случае, если Вы точно знаете, что делаете. Для получения подробной информации об этих настройках, посетите &lt;a href="http://docs.cksource.com/ckeditor_api/symbols/CKEDITOR.config.html"&gt;&lt;strong&gt;страницу документации CKEditor JavaScript API&lt;/strong&gt;&lt;/a&gt;. Вы можете оставить эти настройки пустыми, чтобы загрузить настройки по-умолчанию тогда, когда редактор будет загружаться.</value>
+  </data>
+  <data name="ModuleInstance.Text" xml:space="preserve">
+    <value>Модуль</value>
+  </data>
+  <data name="Page.Text" xml:space="preserve">
+    <value>Страница</value>
+  </data>
+  <data name="Portal.Text" xml:space="preserve">
+    <value>Сайт</value>
+  </data>
+  <data name="RemoveModuleChild.Help" xml:space="preserve">
+    <value>Удалить настройки всех модулей на текущей странице</value>
+  </data>
+  <data name="RemoveModuleChild.Text" xml:space="preserve">
+    <value>Удалить настройки всех модулей на странице</value>
+  </data>
+  <data name="RemovePageChild.Help" xml:space="preserve">
+    <value>Удаление всех настроек дочерних страниц текущей страницы</value>
+  </data>
+  <data name="RemovePageChild.Text" xml:space="preserve">
+    <value>Удалить настройки дочерних страниц</value>
+  </data>
+  <data name="RowBreak.Text" xml:space="preserve">
+    <value>Разделитель строк</value>
+  </data>
+  <data name="AddRowBreakLabel.Text" xml:space="preserve">
+    <value>Добавить разделитель строк</value>
+  </data>
+  <data name="AddRowBreakTitle.Text" xml:space="preserve">
+    <value>Добавить новый разделитель строк в набор панелей</value>
+  </data>
+  <data name="DefaultLinkMode0.Text" xml:space="preserve">
+    <value>Относительный URL</value>
+  </data>
+  <data name="DefaultLinkMode1.Text" xml:space="preserve">
+    <value>Абсолютный URL</value>
+  </data>
+  <data name="DefaultLinkMode2.Text" xml:space="preserve">
+    <value>Относительный защищенный URL</value>
+  </data>
+  <data name="DefaultLinkMode3.Text" xml:space="preserve">
+    <value>Абсолютный защищенный URL</value>
+  </data>
+  <data name="DefaultLinkModeLabel.Text" xml:space="preserve">
+    <value>Режим ссылок по-умолчанию</value>
+  </data>
+  <data name="DetailView.Text" xml:space="preserve">
+    <value>Подробно</value>
+  </data>
+  <data name="IconsView.Text" xml:space="preserve">
+    <value>Значки</value>
+  </data>
+  <data name="ListView.Text" xml:space="preserve">
+    <value>Список</value>
+  </data>
+  <data name="BlanktextTT.Text" xml:space="preserve">
+    <value>Это текст, отображаемый по-умолчанию, когда содержимое модуля отсутствует.</value>
+  </data>
+  <data name="NewsArcticlesArticlesList.Text" xml:space="preserve">
+    <value>Выберите статью:</value>
+  </data>
+  <data name="NewsArcticlesModuleList.Text" xml:space="preserve">
+    <value>Выберите страницу и экземпляр модуля News Articles:</value>
+  </data>
+  <data name="ToolbarNameMissing.Text" xml:space="preserve">
+    <value>Укажите название панели инструментов</value>
+  </data>
+  <data name="ToolbarSetCreated.Text" xml:space="preserve">
+    <value>Создан набор панелей "{0}"!</value>
+  </data>
+  <data name="ToolbarSetDeleted.Text" xml:space="preserve">
+    <value>Выбранный набор панелей удален!</value>
+  </data>
+  <data name="ToolbarSetSaved.Text" xml:space="preserve">
+    <value>Набор панелей сохранен!</value>
+  </data>
+  <data name="CustomJsFileLabel.Text" xml:space="preserve">
+    <value>Пользовательский файл JS</value>
+  </data>
+  <data name="OverrideFileOnUploadLabel.Text" xml:space="preserve">
+    <value>Перезаписать файл, если существует, или создать файл с именем, к которому будет добавлено _1?</value>
+  </data>
+  <data name="CopyPageChild.Help" xml:space="preserve">
+    <value>Копировать настройки текущей страницы для подчиненных</value>
+  </data>
+  <data name="CopyPageChild.Text" xml:space="preserve">
+    <value>Копировать настройки для подчиненных</value>
+  </data>
+  <data name="lblInfoCopyAll.Text" xml:space="preserve">
+    <value>Настройки скопированы для всех подчиненных страниц.</value>
+  </data>
+  <data name="SizeLimitLabel.Text" xml:space="preserve">
+    <value>Максимальный размер файла для подгрузки</value>
+  </data>
+  <data name="UploadFileLimitLabel.Text" xml:space="preserve">
+    <value>Ограничения подгружаемых файлов:</value>
+  </data>
+  <data name="LoadingEditor.Text" xml:space="preserve">
+    <value>CKEditor загружается, подождите, пожалуйста...</value>
+  </data>
+</root>


### PR DESCRIPTION
This adds russian (ru-RU) translation for CKEditor. Based on https://github.com/roman-yagodin/R7.DnnLocalization/tree/master/CKEditor code (added resx schema header). Already pushed to https://github.com/w8tcha/dnnckeditor: https://github.com/w8tcha/dnnckeditor/commit/19772145c73d8ef8745c59e82d445135a241d6d5
