### PR TITLE
DNN-8485 - Fix contentcss rendering

### DIFF
--- a/Web/EditorControl.cs
+++ b/Web/EditorControl.cs
@@ -339,7 +339,7 @@ namespace DNNConnect.CKEditorProvider.Web
 
                 if (!string.IsNullOrEmpty(currentSettings.Config.ContentsCss))
                 {
-                    var customCss = Globals.ResolveUrl(ReFormatURL(currentSettings.Config.ContentsCss));
+                    var customCss = Globals.ResolveUrl(FormatUrl(currentSettings.Config.ContentsCss));
                     resolvedCssFiles.Add(customCss);
                 }
 


### PR DESCRIPTION
The ContentCSS value is stored in the database as FileId=XXX. When rendering the editor the CSS link needs to be reformated to retrieve the actual file name.

This fixes issue #67 
