### PR TITLE
Prevent unnecessary looping through cke settings

### DIFF
--- a/Utilities/SettingsUtil.cs
+++ b/Utilities/SettingsUtil.cs
@@ -96,9 +96,12 @@ namespace DNNConnect.CKEditorProvider.Utilities
             var roles = new ArrayList();
 
             // Import all Editor config settings
-            foreach (PropertyInfo info in GetEditorConfigProperties())
+            var props = GetEditorConfigProperties().ToList();
+            var filteredSettings = editorHostSettings.Where(s => s.Name.StartsWith(key)).ToList();
+
+            foreach (PropertyInfo info in props)
             {
-                if (!editorHostSettings.Any(s => s.Name.Equals(string.Format("{0}{1}", key, info.Name))))
+                if (!filteredSettings.Any(s => s.Name.Equals(string.Format("{0}{1}", key, info.Name))))
                 {
                     continue;
                 }
@@ -109,7 +112,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                 }*/
 
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         setting => setting.Name.Equals(string.Format("{0}{1}", key, info.Name))).Value;
 
                 if (string.IsNullOrEmpty(settingValue))
@@ -169,7 +172,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                             {
                                 case "String":
                                     if (
-                                        editorHostSettings.Any(
+                                        filteredSettings.Any(
                                             s => s.Name.Equals(string.Format("{0}{1}", key, codeMirrorInfo.Name))))
                                     {
                                         codeMirrorInfo.SetValue(currentSettings.Config.CodeMirror, settingValue, null);
@@ -178,7 +181,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                     break;
                                 case "Boolean":
                                     if (
-                                        editorHostSettings.Any(
+                                        filteredSettings.Any(
                                             s => s.Name.Equals(string.Format("{0}{1}", key, codeMirrorInfo.Name))))
                                     {
                                         codeMirrorInfo.SetValue(
@@ -199,7 +202,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                             {
                                 case "String":
                                     if (
-                                        editorHostSettings.Any(
+                                        filteredSettings.Any(
                                             s => s.Name.Equals(string.Format("{0}{1}", key, wordCountInfo.Name))))
                                     {
                                         wordCountInfo.SetValue(currentSettings.Config.WordCount, settingValue, null);
@@ -208,7 +211,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                     break;
                                 case "Boolean":
                                     if (
-                                        editorHostSettings.Any(
+                                        filteredSettings.Any(
                                             s => s.Name.Equals(string.Format("{0}{1}", key, wordCountInfo.Name))))
                                     {
                                         wordCountInfo.SetValue(
@@ -228,11 +231,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             /////////////////
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SKIN))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SKIN))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -242,11 +245,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CODEMIRRORTHEME))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CODEMIRRORTHEME))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -257,7 +260,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
 
             List<ToolbarRoles> listToolbarRoles = (from RoleInfo objRole in portalRoles
                                                    where
-                                                       editorHostSettings.Any(
+                                                       filteredSettings.Any(
                                                            setting =>
                                                            setting.Name.Equals(
                                                                string.Format(
@@ -267,7 +270,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                                                    SettingConstants.TOOLB)))
                                                    where
                                                        !string.IsNullOrEmpty(
-                                                           editorHostSettings.FirstOrDefault(
+                                                           filteredSettings.FirstOrDefault(
                                                                s =>
                                                                s.Name.Equals(
                                                                    string.Format(
@@ -276,7 +279,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                                                        objRole.RoleID,
                                                                        SettingConstants.TOOLB))).Value)
                                                    let sToolbar =
-                                                       editorHostSettings.FirstOrDefault(
+                                                       filteredSettings.FirstOrDefault(
                                                            s =>
                                                            s.Name.Equals(
                                                                string.Format(
@@ -289,11 +292,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
                 .ToList();
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{2}#{1}", key, "-1", SettingConstants.TOOLB))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{2}#{1}", key, "-1", SettingConstants.TOOLB))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -306,7 +309,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
 
             var listUploadSizeRoles = (from RoleInfo objRole in portalRoles
                                        where
-                                           editorHostSettings.Any(
+                                           filteredSettings.Any(
                                                setting =>
                                                setting.Name.Equals(
                                                    string.Format(
@@ -316,7 +319,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                                        SettingConstants.UPLOADFILELIMITS)))
                                        where
                                            !string.IsNullOrEmpty(
-                                               editorHostSettings.FirstOrDefault(
+                                               filteredSettings.FirstOrDefault(
                                                    s =>
                                                    s.Name.Equals(
                                                        string.Format(
@@ -325,7 +328,7 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                                            objRole.RoleID,
                                                            SettingConstants.UPLOADFILELIMITS))).Value)
                                        let uploadFileLimit =
-                                           editorHostSettings.FirstOrDefault(
+                                           filteredSettings.FirstOrDefault(
                                                s =>
                                                s.Name.Equals(
                                                    string.Format(
@@ -338,11 +341,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
                 .ToList();
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{2}#{1}", key, "-1", SettingConstants.UPLOADFILELIMITS))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{2}#{1}", key, "-1", SettingConstants.UPLOADFILELIMITS))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -354,11 +357,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             currentSettings.UploadSizeRoles = listUploadSizeRoles;
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.ROLES))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.ROLES))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -389,11 +392,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BROWSER))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BROWSER))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -438,11 +441,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.INJECTJS))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.INJECTJS))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -456,11 +459,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.WIDTH))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.WIDTH))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -470,11 +473,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.HEIGHT))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.HEIGHT))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -484,11 +487,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BLANKTEXT))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BLANKTEXT))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -498,11 +501,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CSS))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CSS))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -512,11 +515,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.TEMPLATEFILES))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.TEMPLATEFILES))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -526,11 +529,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CUSTOMJSFILE))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CUSTOMJSFILE))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -540,11 +543,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CONFIG))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.CONFIG))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -554,11 +557,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.FILELISTPAGESIZE))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.FILELISTPAGESIZE))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -568,11 +571,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.FILELISTVIEWMODE))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.FILELISTVIEWMODE))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -582,11 +585,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.DEFAULTLINKMODE))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.DEFAULTLINKMODE))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -596,11 +599,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.USEANCHORSELECTOR))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.USEANCHORSELECTOR))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -614,11 +617,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SHOWPAGELINKSTABFIRST))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SHOWPAGELINKSTABFIRST))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -632,11 +635,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.OVERRIDEFILEONUPLOAD))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.OVERRIDEFILEONUPLOAD))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -650,11 +653,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SUBDIRS))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.SUBDIRS))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -668,11 +671,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BROWSERROOTDIRID))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.BROWSERROOTDIRID))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -689,11 +692,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.UPLOADDIRID))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.UPLOADDIRID))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -710,11 +713,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTH))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEWIDTH))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))
@@ -731,11 +734,11 @@ namespace DNNConnect.CKEditorProvider.Utilities
             }
 
             if (
-                editorHostSettings.Any(
+                filteredSettings.Any(
                     setting => setting.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHT))))
             {
                 var settingValue =
-                    editorHostSettings.FirstOrDefault(
+                    filteredSettings.FirstOrDefault(
                         s => s.Name.Equals(string.Format("{0}{1}", key, SettingConstants.RESIZEHEIGHT))).Value;
 
                 if (!string.IsNullOrEmpty(settingValue))


### PR DESCRIPTION
When there are a large number of portals, there is a severe performance
penalty when building the cke settings.  The first step to fixing this is
to limit the number of records being looped through to just the settings
matching the settings prefix when loading settings overrides for portals,
tabs, and modules instead of every record in the database table.  This has
a very large immediate performance improvement.
