### PR TITLE
Update sln file for VS 2015

### DIFF
--- a/DNNConnect.CKEditorProvider.sln
+++ b/DNNConnect.CKEditorProvider.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DNNConnect.CKEditorProvider", "DNNConnect.CKEditorProvider.csproj", "{AE7E021E-7C7B-4003-9BD6-5A04C781C277}"
 EndProject


### PR DESCRIPTION
This PR is an attempt to get AppVeyor to support C# 6, by using MSBuild version 14 instead of version 12