### PR TITLE
Removed dead "Spell Checker" button from CK Editor toolbar.

### DIFF
--- a/Utilities/ToolbarUtil.cs
+++ b/Utilities/ToolbarUtil.cs
@@ -270,13 +270,6 @@ namespace DNNConnect.CKEditorProvider.Utilities
                                                              },
                                                          new ToolbarButton
                                                              {
-                                                                 ToolbarName =
-                                                                     "SpellChecker",
-                                                                 ToolbarIcon =
-                                                                     "SpellChecker.png"
-                                                             },
-                                                         new ToolbarButton
-                                                             {
                                                                  ToolbarName = "Scayt",
                                                                  ToolbarIcon =
                                                                      "SpellChecker.png"


### PR DESCRIPTION
This button is not actually bound to any Spell Checker library. The only usable spell checker we have is SCAYT.