### PR TITLE
CKE Settings: File Browser Settings not stored in the View

### DIFF
--- a/CKEditorOptions.ascx.cs
+++ b/CKEditorOptions.ascx.cs
@@ -284,8 +284,6 @@ namespace DNNConnect.CKEditorProvider
 
                 listToolbars = ToolbarUtil.GetToolbars(HomeDirectory, configFolder);
 
-                FillFolders();
-
                 RenderUrlControls(true);
 
                 FillRoles();
@@ -383,6 +381,8 @@ namespace DNNConnect.CKEditorProvider
 
                 BindUserGroupsGridView();
 
+                FillFolders();
+
                 BindOptionsData();
 
                 SetLanguage();
@@ -391,8 +391,6 @@ namespace DNNConnect.CKEditorProvider
 
                 // Load Skin List
                 FillSkinList();
-
-                FillFolders();
 
                 RenderUrlControls();
 


### PR DESCRIPTION
fixes https://github.com/DNN-Connect/CKEditorProvider/issues/98

Dropdowns folder list is loaded twice. 
Current call stack: `BindOptionsData() -> FillFolders() -> Set dropdown values -> FillFolders() !!!!`
The last call makes drowpdowns resets to their default values. This is a typo and we need to avoid last call.
Should be like:
`FillFolders() -> BindOptionsData() -> Set dropdown values`