### PR TITLE
CKEditor Settings: current skin not selected in dropdown

### DIFF
--- a/CKEditorOptions.ascx.cs
+++ b/CKEditorOptions.ascx.cs
@@ -1187,6 +1187,8 @@ namespace DNNConnect.CKEditorProvider
                 ddlSkin.Items.Add(skinItem);
             }
 
+            ddlSkin.SelectedValue = currentSettings?.Config?.Skin?? "";
+
             // CodeMirror Themes
             CodeMirrorTheme.Items.Clear();
 


### PR DESCRIPTION
Bugfix: select current value in Skin's dropdown