### PR TITLE
Site Name & Portal ID is not displayed on default loading of HTML Editor Manager

### DIFF
--- a/CKEditorOptions.ascx.cs
+++ b/CKEditorOptions.ascx.cs
@@ -386,10 +386,10 @@ namespace DNNConnect.CKEditorProvider
                 BindUserGroupsGridView();
 
                 FillFolders();
-                
-                BindOptionsData();
 
                 SetLanguage();
+
+                BindOptionsData();                
 
                 FillInformations();
 


### PR DESCRIPTION
fixes https://github.com/DNN-Connect/CKEditorProvider/issues/116

On a page load, label is created properly when `BindOptionsData()` is invoked. But then we override it with a default value when getting localized version of a label from resource file on `SetLanguage()`.
To ovoid that, need to get all translations first, then we need to bind settings.