### PR TITLE
UI of Export & Import Setting Explorer is broken

### DIFF
--- a/css/Options.css
+++ b/css/Options.css
@@ -173,3 +173,6 @@ input[type="text"] {
 .ui-selectgroup-optgroup span {display: block; padding: 5px 0;}
 .ui-selectgroup-optgroup ul {list-style: none; padding: 0;margin: 0; }
 .ui-selectgroup-optgroup li {padding: 0 0 0 10px; margin: 0 0 0 -5px;}
+
+#ImportDialog.ui-dialog-content {margin-top:10px;margin-bottom:10px;}
+#ExportDialog.ui-dialog-content {margin-top:10px;margin-bottom:10px;}

--- a/js/Options.js
+++ b/js/Options.js
@@ -61,6 +61,8 @@
         $('#ExportDialog').dialog({
             autoOpen: false,
             width: 350,
+            dialogClass: 'dnnFormPopup',
+            resizable: false,
             buttons: {
                 "Cancel": function () {
                     $(this).dialog("close");
@@ -77,6 +79,8 @@
         $('#ImportDialog').dialog({
             autoOpen: false,
             width: 350,
+            dialogClass: 'dnnFormPopup',
+            resizable: false,
             buttons: {
                  "Cancel": function() {
                      $(this).dialog("close");


### PR DESCRIPTION
fixes https://github.com/DNN-Connect/CKEditorProvider/issues/118


I found `ui-dialog` is fully missing in CKEditor styles. However, default DNN styles describes styles of such dialog's well. Adding extra class `dnnFormPopup` to the ui dialog completely fixes the problem. 
See result below. 

![image](https://user-images.githubusercontent.com/22524011/60191779-8eef8680-983d-11e9-9f36-7428a96a8fde.png)


