### PR TITLE
CK Editor: Browser - Taking a long time to load

### DIFF
--- a/Browser/Browser.aspx.cs
+++ b/Browser/Browser.aspx.cs
@@ -1479,18 +1479,18 @@ namespace DNNConnect.CKEditorProvider.Browser
             //      Key = parrent folder id 
             //      Value = list of child folders
             // this will let us possible to create folders tree much faster on a recursion below
-            var readOnlyFolders = FolderManager.Instance.GetFolders(UserController.Instance.GetCurrentUserInfo())
+            var readableFolders = FolderManager.Instance.GetFolders(UserController.Instance.GetCurrentUserInfo())
                 .GroupBy(folder => folder.ParentID)
                 .ToDictionary(key => key.Key, value => value?.Select(folder => folder) ?? Enumerable.Empty<IFolderInfo>());
 
             // get all folders where parrent folder is current one
-            if (!readOnlyFolders.TryGetValue(currentFolderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
+            if (!readableFolders.TryGetValue(currentFolderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
             {
                 return;
             }
 
             foreach (TreeNode node in
-                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readOnlyFolders)).Where(node => node != null))
+                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readableFolders)).Where(node => node != null))
             {
                 folderNode.ChildNodes.Add(node);
             }
@@ -1718,11 +1718,11 @@ namespace DNNConnect.CKEditorProvider.Browser
         /// Render all Directories and sub directories recursive
         /// </summary>
         /// <param name="folderInfo">The folder Info.</param>
-        /// <param name="readOnlyFolders"></param>
+        /// <param name="readableFolders">The list of folders that the current user has READ access</param>
         /// <returns>
         /// TreeNode List
         /// </returns>
-        private TreeNode RenderFolder(FolderInfo folderInfo, IDictionary<int, IEnumerable<IFolderInfo>> readOnlyFolders)
+        private TreeNode RenderFolder(FolderInfo folderInfo, IDictionary<int, IEnumerable<IFolderInfo>> readableFolders)
         {
             TreeNode tnFolder = new TreeNode
             {
@@ -1731,13 +1731,13 @@ namespace DNNConnect.CKEditorProvider.Browser
                 ImageUrl = GetFolderIcon(folderInfo)
             };
 
-            if (!readOnlyFolders.TryGetValue(folderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
+            if (!readableFolders.TryGetValue(folderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
             {
                 return tnFolder;
             }
 
             foreach (TreeNode node in
-                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readOnlyFolders)).Where(node => node != null))
+                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readableFolders)).Where(node => node != null))
             {
                 tnFolder.ChildNodes.Add(node);
             }

--- a/Browser/Browser.aspx.cs
+++ b/Browser/Browser.aspx.cs
@@ -253,6 +253,9 @@ namespace DNNConnect.CKEditorProvider.Browser
         /// </returns>
         public DataTable GetFiles(IFolderInfo currentFolderInfo)
         {
+            var sizeResx = Localization.GetString("Size.Text", ResXFile, LanguageCode);
+            var createdResx = Localization.GetString("Created.Text", ResXFile, LanguageCode);
+
             var filesTable = new DataTable();
 
             filesTable.Columns.Add(new DataColumn("FileName", typeof(string)));
@@ -294,19 +297,18 @@ namespace DNNConnect.CKEditorProvider.Browser
                 {
                     case "Image":
                         {
-                            foreach (DataRow dr in
-                                from sAllowExt in allowedImageExt
-                                where name.ToLower().EndsWith(sAllowExt)
-                                select filesTable.NewRow())
+                            if (Array.IndexOf(allowedImageExt, extension) >= 0)
                             {
+                                var dr = filesTable.NewRow();
+
                                 dr["PictureURL"] = FileManager.Instance.GetUrl(fileItem);
                                 dr["FileName"] = name;
                                 dr["FileId"] = item.FileId;
 
                                 dr["Info"] =
                                     string.Format(fileItemDisplayFormat,
-                                            Localization.GetString("Size.Text", ResXFile, LanguageCode),
-                                            Localization.GetString("Created.Text", ResXFile, LanguageCode),
+                                            sizeResx,
+                                            createdResx,
                                             name,
                                             fileItem.Size,
                                             fileItem.LastModificationTime);
@@ -318,17 +320,16 @@ namespace DNNConnect.CKEditorProvider.Browser
                         break;
                     case "Flash":
                         {
-                            foreach (DataRow dr in
-                                from sAllowExt in allowedFlashExt
-                                where name.ToLower().EndsWith(sAllowExt)
-                                select filesTable.NewRow())
+                            if (Array.IndexOf(allowedFlashExt, extension) >= 0)
                             {
+                                var dr = filesTable.NewRow();
+
                                 dr["PictureURL"] = "images/types/swf.png";
 
                                 dr["Info"] =
                                     string.Format(fileItemDisplayFormat,
-                                            Localization.GetString("Size.Text", ResXFile, LanguageCode),
-                                            Localization.GetString("Created.Text", ResXFile, LanguageCode),
+                                            sizeResx,
+                                            createdResx,
                                             name,
                                             fileItem.Size,
                                             fileItem.LastModificationTime);
@@ -377,8 +378,8 @@ namespace DNNConnect.CKEditorProvider.Browser
 
                             dr["Info"] =
                                 string.Format(fileItemDisplayFormat,
-                                        Localization.GetString("Size.Text", ResXFile, LanguageCode),
-                                        Localization.GetString("Created.Text", ResXFile, LanguageCode),
+                                        sizeResx,
+                                        createdResx,
                                         name,
                                         fileItem.Size,
                                         fileItem.LastModificationTime);
@@ -1474,10 +1475,22 @@ namespace DNNConnect.CKEditorProvider.Browser
 
             FoldersTree.Nodes.Add(folderNode);
 
-            var folders = FolderManager.Instance.GetFolders(currentFolderInfo);
+            // gets the list of folders the specified user has read permissions and transfrom into dictionary:
+            //      Key = parrent folder id 
+            //      Value = list of child folders
+            // this will let us possible to create folders tree much faster on a recursion below
+            var readOnlyFolders = FolderManager.Instance.GetFolders(UserController.Instance.GetCurrentUserInfo())
+                .GroupBy(folder => folder.ParentID)
+                .ToDictionary(key => key.Key, value => value?.Select(folder => folder) ?? Enumerable.Empty<IFolderInfo>());
+
+            // get all folders where parrent folder is current one
+            if (!readOnlyFolders.TryGetValue(currentFolderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
+            {
+                return;
+            }
 
             foreach (TreeNode node in
-                folders.Cast<FolderInfo>().Select(RenderFolder).Where(node => node != null))
+                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readOnlyFolders)).Where(node => node != null))
             {
                 folderNode.ChildNodes.Add(node);
             }
@@ -1705,16 +1718,12 @@ namespace DNNConnect.CKEditorProvider.Browser
         /// Render all Directories and sub directories recursive
         /// </summary>
         /// <param name="folderInfo">The folder Info.</param>
+        /// <param name="readOnlyFolders"></param>
         /// <returns>
         /// TreeNode List
         /// </returns>
-        private TreeNode RenderFolder(FolderInfo folderInfo)
+        private TreeNode RenderFolder(FolderInfo folderInfo, IDictionary<int, IEnumerable<IFolderInfo>> readOnlyFolders)
         {
-            if (!FolderPermissionController.CanViewFolder(folderInfo))
-            {
-                return null;
-            }
-
             TreeNode tnFolder = new TreeNode
             {
                 Text = folderInfo.FolderName,
@@ -1722,15 +1731,13 @@ namespace DNNConnect.CKEditorProvider.Browser
                 ImageUrl = GetFolderIcon(folderInfo)
             };
 
-            var folders = FolderManager.Instance.GetFolders(folderInfo).ToList();
-
-            if (!folders.Any())
+            if (!readOnlyFolders.TryGetValue(folderInfo.FolderID, out IEnumerable<IFolderInfo> folders))
             {
                 return tnFolder;
             }
 
             foreach (TreeNode node in
-                folders.Cast<FolderInfo>().Select(RenderFolder).Where(node => node != null))
+                folders.Cast<FolderInfo>().Select(folder => RenderFolder(folder, readOnlyFolders)).Where(node => node != null))
             {
                 tnFolder.ChildNodes.Add(node);
             }


### PR DESCRIPTION
fixes https://github.com/DNN-Connect/CKEditorProvider/issues/121

See also another part of the fix: https://github.com/dnnsoftware/Dnn.Platform/pull/2903

Summary:
There is a huge performance issue when loading huge amount of folders in one tree. The main reason is that we call `FolderPermissionController.CanViewFolder(folderInfo)` on every iteration. Loading around of 20K items it makes db call to check permission for every folder. To avoid that, I used another API to get list of folders that given user has read permission, see

https://github.com/dnnsoftware/Dnn.Platform/blob/316a354ed6ceb13804a1f72dcdcf146b61d7406e/DNN%20Platform/Library/Services/FileSystem/FolderManager.cs#L776

Now it invokes db call only once. Apart of that I also refactored the code a bit to accelerate loading process.

20K folders are now loaded in a few seconds.

See DEMO: [DEMO](https://drive.google.com/file/d/1Z1tOcaOcksK8bTwNW-x9AZCHDt66ioa_/view?usp=sharing)