### PR TITLE
Removes duplicate dll packaging

### DIFF
--- a/BuildScripts/Package.targets
+++ b/BuildScripts/Package.targets
@@ -14,7 +14,7 @@
   <Import Project="$(BuildScriptsPath)\MSBuild.Community.Tasks.Targets" />
   <UsingTask AssemblyFile="$(DotNetNukeMSBuildTasksLib)" TaskName="DotNetNuke.MSBuild.Tasks.ExtensionPackager" />
 
-  <Target Name="AfterBuild" DependsOnTargets="CopyBin;GetFiles;Package">
+  <Target Name="AfterBuild" DependsOnTargets="GetFiles;Package">
   </Target>
 
   <Target Name="CopyBin">
@@ -85,6 +85,7 @@
     <CreateItem Include="$(MSBuildProjectDirectory)\Package\**\*.*">
       <Output TaskParameter="Include" ItemName="OutputContent" />
     </CreateItem>
+    <Message importance="High" text="@(OutputContent)"></Message>
     <Zip Files="@(OutputContent)" WorkingDirectory="$(MSBuildProjectDirectory)\Package" ZipFileName="$(PackageName)_$(Version)_Install.$(Extension)" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\$(PackageName)_$(Version)_Install.$(Extension)" DestinationFolder="$(PackagePath)" />
     <Delete Files="$(MSBuildProjectDirectory)\$(PackageName)_$(Version)_Install.$(Extension)" />

--- a/BuildScripts/Package.targets
+++ b/BuildScripts/Package.targets
@@ -85,7 +85,6 @@
     <CreateItem Include="$(MSBuildProjectDirectory)\Package\**\*.*">
       <Output TaskParameter="Include" ItemName="OutputContent" />
     </CreateItem>
-    <Message importance="High" text="@(OutputContent)"></Message>
     <Zip Files="@(OutputContent)" WorkingDirectory="$(MSBuildProjectDirectory)\Package" ZipFileName="$(PackageName)_$(Version)_Install.$(Extension)" />
     <Copy SourceFiles="$(MSBuildProjectDirectory)\$(PackageName)_$(Version)_Install.$(Extension)" DestinationFolder="$(PackagePath)" />
     <Delete Files="$(MSBuildProjectDirectory)\$(PackageName)_$(Version)_Install.$(Extension)" />

--- a/DNNConnect.CKEditorProvider.csproj
+++ b/DNNConnect.CKEditorProvider.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -220,6 +220,9 @@
     <Content Include="Browser\js\jquery.ImageResizer.js" />
     <Content Include="Browser\js\jquery.ImageSlider.js" />
     <Content Include="Browser\js\jquery.pagemethod.js" />
+    <Content Include="BuildScripts\DotNetNuke.MSBuild.Tasks.dll" />
+    <Content Include="BuildScripts\ICSharpCode.SharpZipLib.dll" />
+    <Content Include="BuildScripts\MSBuild.Community.Tasks.dll" />
     <Content Include="CKEditorConfig.png" />
     <Content Include="css\CKEditorOverride.css" />
     <Content Include="css\CkEditorContents.css" />
@@ -280,6 +283,8 @@
     <Content Include="Browser\FileUploader.ashx" />
     <Content Include="Browser\Browser.comb.css.bundle" />
     <Content Include="Install\01.00.00.SqlDataProvider" />
+    <Content Include="BuildScripts\MSBuild.Community.Tasks.Targets" />
+    <Content Include="BuildScripts\Package.targets" />
     <None Include="Install\Uninstall.SqlDataProvider" />
     <None Include="DNNConnect.CKEditorProvider.dnn">
       <SubType>Designer</SubType>


### PR DESCRIPTION
There was a CopyBin target and the Dnn ExtensionPackager already picked up the module dll. So the Dll was listed twice as a relative and an absolute path. This is why the dll was present twice in the zip although it would have been impossible in the filesystem.

For a quick fix and to not break anything else, I just removed the CopyBin call thus avoiding this duplication and allowing for a quick 9.4.1 release that installs.

A better solution might be to improve the whole build script, but we could do this later.

Closes #125 and https://github.com/dnnsoftware/Dnn.Platform/issues/2962